### PR TITLE
Removed 'xorshift128.h' from SConstruct in samples/XORSHIFT

### DIFF
--- a/samples/XORSHIFT/SConstruct
+++ b/samples/XORSHIFT/SConstruct
@@ -52,6 +52,6 @@ env.Program('xorshift-2', ['xorshift-2.cpp'], LIBS=optlib)
 env.Program('xorshift-3', ['xorshift-3.cpp'], LIBS=optlib)
 env.Program('xorshift-4', ['xorshift-4.cpp'], LIBS=optlib)
 env.Program('xorshift-5', ['xorshift-5.cpp'], LIBS=optlib)
-env.Program('xorshift128', ['xorshift128.c', 'xorshift128.h'], LIBS=optlib)
+env.Program('xorshift128', ['xorshift128.c'], LIBS=optlib)
 
 Clean('all', Glob('*.o'))


### PR DESCRIPTION
'xorshift128.h' を取り除いてコンパイルエラーを解消しました。
